### PR TITLE
Change shebang to sh.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+dist: trusty
+sudo: false
+language: go
+os:
+  - linux

--- a/tcp-port-wait.sh
+++ b/tcp-port-wait.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 if [ -z "$1" -o -z "$2" ]


### PR DESCRIPTION
Guys,

Change the shebang to `sh` for works on alpine too without install bash.

Best regards,